### PR TITLE
Harden Roots site content and external surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Welcome to the official repository for the Shropshire Roots Brotherhood website.
 
 **Shropshire Roots Brotherhood** is a community interest organization dedicated to fostering a supportive environment for men's mental health. Our mission is to create a space for genuine conversations, transformative activities, and a deep connection with nature, helping men build strength, resilience, and integrity.
 
-This website serves as a central hub for information about our mission, upcoming events, donation opportunities, and ways to get involved.
+This website serves as a central hub for information about our mission, community activities, and ways to get involved.
 
 ## Getting Started
 
@@ -34,7 +34,7 @@ Ensure you have the following installed:
 1. Clone the repository:
 
     ```bash
-    git clone https://github.com/wjg7/roots.git
+    git clone https://github.com/wilfgrainger/roots.git
     ```
 
 2. Navigate to the project directory:
@@ -57,8 +57,8 @@ To view the website locally:
 ### Key Features
 
 - **Home Section**: Overview of the organization's mission and values.
-- **Donate Section**: Integration with PayPal for donations.
-- **Events Section**: Information on upcoming meetups and events.
+- **Merchandise Section**: Information about Roots Brotherhood merchandise.
+- **Community Section**: Links to the Brotherhood's public social channels.
 - **Social Media Integration**: Links to the organization's social media profiles.
 - **Responsive Design**: The website is designed to be responsive and user-friendly on all devices.
 
@@ -76,12 +76,12 @@ Please ensure that your contributions adhere to the coding standards and guideli
 
 ## License
 
-This project is licensed under the MIT License. See the [LICENSE] file for more details.
+This project is licensed under the GNU General Public License v3. See the [LICENSE](LICENSE) file for more details.
 
 ## Contact
 
 If you have any questions or need further information, please feel free to contact us at:
 
-- Email: info@shropshireroots.org
-- Website: [Shropshire Roots Brotherhood](https://rootsbrotherhood.org)
-- GitHub: [wjg7](https://github.com/wjg7/roots)
+- Email: info@rootsbrotherhood.org
+- Website: [Shropshire Roots Brotherhood](https://www.rootsbrotherhood.org)
+- GitHub: [wilfgrainger/roots](https://github.com/wilfgrainger/roots)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security
+
+Roots Brotherhood is a static website. It does not provide an account system, application API, payment form, or browser-side collection of health information.
+
+If you find a security issue in the site or repository, please email `info@rootsbrotherhood.org` with the subject **Security report**. Please do not include sensitive personal information in the report.
+
+The site links to third-party services, including social-media platforms. Issues in those services should be reported to their respective providers as well.

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
   <meta property="og:image:alt" content="Shropshire Roots Brotherhood Logo" />
   <meta property="og:url" content="https://www.rootsbrotherhood.org/" />
   <meta property="og:type" content="website" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; script-src 'self'; connect-src 'self'; form-action 'self';" />
   <style>
     html {
       scroll-behavior: smooth;
@@ -98,7 +99,7 @@
     <div class="box-container">
       <div class="box">
         <!-- ⚡ Bolt: Lazy-load below-fold assets to improve LCP -->
-        <img src="assets/imagt="Brotherhood Heavyweight Signature Hoodie" class="merch-image" loading="lazy" />
+        <img src="assets/images/jh120.png" alt="Roots Brotherhood heavyweight signature hoodie" class="merch-image" loading="lazy" />
         <h3>Brotherhood Heavyweight Signature Hoodie</h3>
         <p>Contact us to purchase.</p>
       </div>
@@ -125,11 +126,8 @@
 
   <section id="instagram" class="box-section">
     <h2>News</h2>
-    <!-- ⚡ Bolt: Defer non-critical scripts and lazy-load below-fold assets to improve main thread execution and LCP -->
-    <script src="https://snapwidget.com/js/snapwidget.js" defer></script>
-    <iframe src="https://snapwidget.com/embed/1077046" class="snapwidget-widget" allowtransparency="true"
-      frameborder="0" scrolling="no" style="border:none; overflow:hidden; width:100%; height:600px;"
-      title="Posts from Instagram" loading="lazy"></iframe>
+    <p>Follow the Brotherhood on Instagram for the latest updates.</p>
+    <a href="https://www.instagram.com/roots_brotherhood/" target="_blank" rel="noopener noreferrer" class="btn">Open Instagram</a>
   </section>
 
   <section id="resources" class="box-section">
@@ -265,15 +263,15 @@
         <p>Email: <a href="mailto:info@rootsbrotherhood.org">info@rootsbrotherhood.org</a></p>
         <div style="margin-top: 24px;">
           <p><strong>Crisis Support:</strong></p>
-          <p>Call <strong>111</strong> if you are in crisis.</p>
+          <p>For urgent mental-health help in England, call <strong>111</strong> and select the mental-health option. If someone is in immediate danger, call <strong>999</strong>.</p>
           <p><a
               href="https://www.nhs.uk/nhs-services/mental-health-services/where-to-get-urgent-help-for-mental-health/"
-              target="_blank">NHS Urgent Help</a></p>
+              target="_blank" rel="noopener noreferrer">NHS Urgent Help</a></p>
         </div>
       </div>
     </div>
     <div class="footer-bottom">
-      <p>&copy; 2024 Shropshire Roots Brotherhood</p>
+      <p>&copy; 2026 Shropshire Roots Brotherhood</p>
       <p><a href="privacy.html">Privacy Policy</a> | <a href="terms.html">Terms of Service</a></p>
       <p style="margin-top: 10px; font-size: 12px; opacity: 0.6;">Made by <a href="https://graingers.agency"
           target="_blank" style="text-decoration: underline;">Graingers.Agency</a></p>

--- a/privacy.html
+++ b/privacy.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Privacy Policy - Roots Brotherhood</title>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; script-src 'self'; connect-src 'self'; form-action 'self';" />
   <link rel="icon" href="assets/images/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="assets/css/styles.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -43,30 +44,26 @@
   <section id="privacy" class="box-section"
     style="text-align: left; padding: 40px 20px; max-width: 800px; margin: 40px auto; min-height: 60vh;">
     <h2>Privacy Policy</h2>
-    <p>This privacy notice tells you what to expect us to do with your personal information.</p>
+    <p>This privacy notice explains what happens to information you choose to share when you use this website or contact the Roots Brotherhood.</p>
 
     <h3>Contact Details</h3>
-    <p>Email: <a href="mailto:info@shropshireroots.org">info@shropshireroots.org</a></p>
+    <p>Roots Brotherhood can be contacted at <a href="mailto:info@rootsbrotherhood.org">info@rootsbrotherhood.org</a>.</p>
 
-    <h3>What Information We Collect, Use, and Why</h3>
-    <p>We collect or use the following information to provide services and goods, including delivery and third-party
-      referrals:</p>
+    <h3>Information handled through this website</h3>
+    <p>This static website does not currently provide an account, payment form, booking form, or health questionnaire. If you email us, we receive the information you choose to include so that we can respond to your enquiry.</p>
     <ul>
-      <li>Names and contact details</li>
-      <li>Addresses</li>
-      <li>Date of birth</li>
-      <li>Emergency contact details</li>
-      <li>Photographs or video recordings</li>
-      <li>Health information</li>
-      <li>Dietary information</li>
+      <li>Do not include sensitive health, emergency-contact, or other special-category information in an unsolicited email.</li>
+      <li>Links to social-media services take you to third-party platforms with their own privacy practices.</li>
+      <li>The hosting and email providers used to deliver the website and messages may process technical or contact information as part of those services.</li>
     </ul>
 
-    <h3>Lawful Bases and Data Protection Rights</h3>
-    <p>Under UK data protection law, you have rights including access, rectification, erasure, restriction, objection,
-      and portability.</p>
+    <h3>Your rights</h3>
+    <p>Under UK data-protection law, you may have rights including access, rectification, erasure, restriction, objection, and portability. Contact us first if you want to exercise a right or ask how a particular message has been handled.</p>
 
     <h3>How to Complain</h3>
-    <p>If you have any concerns, please contact us.</p>
+    <p>If you have a concern, please contact us first. You can also contact the <a href="https://ico.org.uk/make-a-complaint/" target="_blank" rel="noopener noreferrer">Information Commissioner's Office</a>.</p>
+
+    <p><small>Last updated: 5 August 2026.</small></p>
   </section>
 
   <footer class="main-footer">
@@ -111,7 +108,7 @@
       </div>
     </div>
     <div class="footer-bottom">
-      <p>&copy; 2024 Shropshire Roots Brotherhood</p>
+      <p>&copy; 2026 Shropshire Roots Brotherhood</p>
       <p><a href="privacy.html">Privacy Policy</a> | <a href="terms.html">Terms of Service</a></p>
       <p style="margin-top: 10px; font-size: 12px; opacity: 0.6;">Made by <a href="https://graingers.agency"
           target="_blank" style="text-decoration: underline;">Graingers.Agency</a></p>

--- a/terms.html
+++ b/terms.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Terms of Service - Roots Brotherhood</title>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; script-src 'self'; connect-src 'self'; form-action 'self';" />
   <link rel="icon" href="assets/images/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="assets/css/styles.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -50,7 +51,7 @@
     <p>You agree to use the site only for lawful purposes.</p>
 
     <h3>3. Content</h3>
-    <p>All content is owned by Shropshire Roots Brotherhood.</p>
+    <p>Unless stated otherwise, site content is provided by Shropshire Roots Brotherhood. Third-party content, services, trademarks, and links remain subject to their respective owners' terms. The website code is distributed under the GNU GPL v3 licence in the repository.</p>
 
     <h3>4. Privacy</h3>
     <p>See our Privacy Policy above.</p>
@@ -98,7 +99,7 @@
       </div>
     </div>
     <div class="footer-bottom">
-      <p>&copy; 2024 Shropshire Roots Brotherhood</p>
+      <p>&copy; 2026 Shropshire Roots Brotherhood</p>
       <p><a href="privacy.html">Privacy Policy</a> | <a href="terms.html">Terms of Service</a></p>
       <p style="margin-top: 10px; font-size: 12px; opacity: 0.6;">Made by <a href="https://graingers.agency"
           target="_blank" style="text-decoration: underline;">Graingers.Agency</a></p>


### PR DESCRIPTION
## Summary

- repair the broken hoodie image reference
- remove the same-page SnapWidget script and replace it with an explicit Instagram link
- add a restrictive CSP to the static pages
- make the privacy notice describe the site's actual current collection surface
- align contact details, licensing, repository URLs, and current-year footer text
- correct the urgent mental-health support wording
- add a short security reporting policy

## Why

The public site contained a broken image, stale repository and licensing claims, inconsistent contact addresses, an overbroad privacy notice, and a third-party script executing in the page context.

## Validation

- parsed `index.html`, `privacy.html`, and `terms.html` with Python's HTML parser
- verified stale image/script/contact/license strings are absent
- ran `git diff --check`

This PR does not alter the organisation's external accounts or collect new user data.